### PR TITLE
Minor phonetic improvements

### DIFF
--- a/script.js
+++ b/script.js
@@ -128,7 +128,11 @@ function setupSource() {
       const voiceGame = schedule.find((g) => g.awayTeamNickname === trackedName || g.homeTeamNickname === trackedName);
       const { lastUpdate } = voiceGame;
       if (lastUpdate && latestUpdate !== lastUpdate) {
-        let utterance = new SpeechSynthesisUtterance(voiceGame.lastUpdate)
+        const phoneticCountMunge = /(?<=\d)-(?=\d$)/;
+        const phoneticZero = /0/g;
+        const phoneticUpdate = voiceGame.lastUpdate.replace(phoneticCountMunge, ' and ').replace(phoneticZero, 'O')
+        console.debug(phoneticUpdate);
+        let utterance = new SpeechSynthesisUtterance(phoneticUpdate)
         if (preferredVoice) {
           utterance.voice = preferredVoice;
         }

--- a/script.js
+++ b/script.js
@@ -138,6 +138,8 @@ function setupSource() {
           } else {
             if (voiceGame.homeScore == 0 && voiceGame.awayScore == 0) {
               halfInningHeader = 'No score at the '
+            } else if (voiceGame.homeScore == voiceGame.awayScore) {
+              halfInningHeader = 'Score tied ' + voiceGame.homeScore + ' all at the '
             } else if (voiceGame.homeScore > voiceGame.awayScore) {
               halfInningHeader = homeScoreString + ', ' + awayScoreString + ' at the '
             } else {

--- a/script.js
+++ b/script.js
@@ -128,9 +128,9 @@ function setupSource() {
       const voiceGame = schedule.find((g) => g.awayTeamNickname === trackedName || g.homeTeamNickname === trackedName);
       const { lastUpdate } = voiceGame;
       if (lastUpdate && latestUpdate !== lastUpdate) {
-        const phoneticInning = /(?<=^(Top|Bottom) of )\d/;
+        const phoneticInning = /(?<=^(Top|Bottom) of )\d+/;
         const phoneticCountMunge = /(?<=\d)-(?=\d$)/;
-        const phoneticZero = /0/g;
+        const phoneticZero = /(?<!\d)0/g;
         const phoneticUpdate = voiceGame.lastUpdate.replace(phoneticInning, 'the ' + ordinal(voiceGame.inning + 1)).replace(phoneticCountMunge, ' and ').replace(phoneticZero, 'O')
         console.debug(phoneticUpdate);
         let utterance = new SpeechSynthesisUtterance(phoneticUpdate)

--- a/script.js
+++ b/script.js
@@ -128,10 +128,26 @@ function setupSource() {
       const voiceGame = schedule.find((g) => g.awayTeamNickname === trackedName || g.homeTeamNickname === trackedName);
       const { lastUpdate } = voiceGame;
       if (lastUpdate && latestUpdate !== lastUpdate) {
+        let halfInningHeader = ''
         const phoneticInning = /(?<=^(Top|Bottom) of )\d+/;
+        if (voiceGame.lastUpdate.match(phoneticInning)) {
+          const awayScoreString = voiceGame.awayTeamNickname + ' ' + voiceGame.awayScore;
+          const homeScoreString = voiceGame.homeTeamNickname + ' ' + voiceGame.homeScore;
+          if (voiceGame.inning == 0 && voiceGame.topOfInning == true) {
+            halfInningHeader = 'Pitching today are ' + voiceGame.awayPitcherName + ' for the ' + voiceGame.awayTeamNickname + ' and ' + voiceGame.homePitcherName + ' for the ' + voiceGame.homeTeamNickname + '. '
+          } else {
+            if (voiceGame.homeScore == 0 && voiceGame.awayScore == 0) {
+              halfInningHeader = 'No score at the '
+            } else if (voiceGame.homeScore > voiceGame.awayScore) {
+              halfInningHeader = homeScoreString + ', ' + awayScoreString + ' at the '
+            } else {
+              halfInningHeader = awayScoreString + ', ' + homeScoreString + ' at the '
+            }
+          }
+        }
         const phoneticCountMunge = /(?<=\d)-(?=\d$)/;
         const phoneticZero = /(?<!\d)0/g;
-        const phoneticUpdate = voiceGame.lastUpdate.replace(phoneticInning, 'the ' + ordinal(voiceGame.inning + 1)).replace(phoneticCountMunge, ' and ').replace(phoneticZero, 'O')
+        const phoneticUpdate = halfInningHeader + voiceGame.lastUpdate.replace(phoneticInning, 'the ' + ordinal(voiceGame.inning + 1)).replace(phoneticCountMunge, ' and ').replace(phoneticZero, 'O');
         console.debug(phoneticUpdate);
         let utterance = new SpeechSynthesisUtterance(phoneticUpdate)
         if (preferredVoice) {

--- a/script.js
+++ b/script.js
@@ -147,7 +147,14 @@ function setupSource() {
         }
         const phoneticCountMunge = /(?<=\d)-(?=\d$)/;
         const phoneticZero = /(?<!\d)0/g;
-        const phoneticUpdate = halfInningHeader + voiceGame.lastUpdate.replace(phoneticInning, 'the ' + ordinal(voiceGame.inning + 1)).replace(phoneticCountMunge, ' and ').replace(phoneticZero, 'O');
+        let phoneticUpdate = halfInningHeader + voiceGame.lastUpdate.replace(phoneticInning, 'the ' + ordinal(voiceGame.inning + 1)).replace(phoneticCountMunge, ' and ').replace(phoneticZero, 'O');
+        if (voiceGame.gameComplete == true) {
+          if (voiceGame.homeScore > voiceGame.awayScore) {
+            phoneticUpdate = phoneticUpdate + ' Final score: ' + voiceGame.homeTeamName + ' ' + voiceGame.homeScore + ', ' + voiceGame.awayTeamName + ' ' + voiceGame.awayScore + '.' + (voiceGame.shame == true ? ' The ' + voiceGame.awayTeamNickname + ' were shamed!' : '')
+          } else {
+            phoneticUpdate = phoneticUpdate + ' Final score: ' + voiceGame.awayTeamName + ' ' + voiceGame.awayScore + ', ' + voiceGame.homeTeamName + ' ' + voiceGame.homeScore + '.' + (voiceGame.shame == true ? ' The ' + voiceGame.homeTeamNickname + ' were shamed!' : '')
+          }
+        }
         console.debug(phoneticUpdate);
         let utterance = new SpeechSynthesisUtterance(phoneticUpdate)
         if (preferredVoice) {

--- a/script.js
+++ b/script.js
@@ -128,9 +128,10 @@ function setupSource() {
       const voiceGame = schedule.find((g) => g.awayTeamNickname === trackedName || g.homeTeamNickname === trackedName);
       const { lastUpdate } = voiceGame;
       if (lastUpdate && latestUpdate !== lastUpdate) {
+        const phoneticInning = /(?<=^(Top|Bottom) of )\d/;
         const phoneticCountMunge = /(?<=\d)-(?=\d$)/;
         const phoneticZero = /0/g;
-        const phoneticUpdate = voiceGame.lastUpdate.replace(phoneticCountMunge, ' and ').replace(phoneticZero, 'O')
+        const phoneticUpdate = voiceGame.lastUpdate.replace(phoneticInning, 'the ' + ordinal(voiceGame.inning + 1)).replace(phoneticCountMunge, ' and ').replace(phoneticZero, 'O')
         console.debug(phoneticUpdate);
         let utterance = new SpeechSynthesisUtterance(phoneticUpdate)
         if (preferredVoice) {


### PR DESCRIPTION
Hello, fellow Blaseball fan!

I like what you did, so I did a small thing, too. To make the synthesized speech a tiny bit more natural, I decided to take voiceGame.lastUpdate and pass it through a bunch of regular expressions, then use the output string for the utterance. Currently it has these effects:

* Innings are announced with the definite article and ordinal numbers: "Bottom of 9" -> "Bottom of the ninth"
* Ball and strike counts are announced the way they are in real base-based ball-games (rather than as a range from "x to y"): "3-1" -> "three and one"
* Zeroes appearing on their own are pronounced "oh": "0-2" -> "oh and two"

These are pretty arbitrary changes, driven almost entirely by my own preferences, but this does introduce a simple way you can refine the announced string either for more natural speech or for better accessibility, especially if the Blaseball Gods ever alter the lastUpdate strings upstream; it may even permit some user customization of preferred strings? Who knows. The method isn't super elegant and you might well imagine a better way to do it, but I really wanted to use this to listen to the post-season, so I started jamming in my browser's developer console and wanted to share. If it's useful, please enjoy!

As ever,
Your Kicks are My Kicks. :athletic_shoe: